### PR TITLE
Merging develop into email_validation again 

### DIFF
--- a/EvilTwitter/EvilAPI/appsettings.json
+++ b/EvilTwitter/EvilAPI/appsettings.json
@@ -1,10 +1,10 @@
 {
   "Serilog": {
     "MinimumLevel": {
-      "Default": "Information",
+      "Default": "Error",
       "Override": {
-        "Microsoft": "Information",
-        "System": "Information"
+        "Microsoft": "Warning",
+        "System": "Warning"
       }
     }
   },
@@ -12,5 +12,5 @@
     "Uri": "http://localhost:9200"
   },
   "AllowedHosts": "*",
-  "version": "1.0.3-*"  
+  "version": "1.0.4-*"  
 }


### PR DESCRIPTION
This is done before mergin email_validation into develop just to make sure everything works, without destroying develop.